### PR TITLE
Feature: iosArm64Simulator target support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,9 @@ kotlin {
     ios {
         binaries.framework()
     }
+
+    iosSimulatorArm64()
+
     android {
         publishLibraryVariants("debug", "release")
     }
@@ -93,6 +96,13 @@ kotlin {
             dependencies {
                 implementation(Libs.ktorIOS)
             }
+        }
+        val iosTest by getting
+        val iosSimulatorArm64Main by getting {
+            dependsOn(iosMain)
+        }
+        val iosSimulatorArm64Test by getting {
+            dependsOn(iosTest)
         }
         val jsMain by getting {
             dependencies {

--- a/buildSrc/src/main/java/Libs.kt
+++ b/buildSrc/src/main/java/Libs.kt
@@ -15,7 +15,7 @@ object Versions {
     const val definitions = "4.41.0"
     const val coroutines = "1.5.2-native-mt"
     const val serialization = "1.3.0"
-    const val ktor = "1.6.4"
+    const val ktor = "1.6.5"
     const val TestCore = "1.2.0"
     const val RoboElectric = "4.5.1"
 }


### PR DESCRIPTION
Bumped Ktor to 1.6.5 and added the target. ~~Seems like `ktor-client-serialization` 1.6.5 has not been published yet.~~