### PR TITLE
Fix response of the resend confirmation code request

### DIFF
--- a/src/commonMain/kotlin/com/liftric/cognito/idp/IdentityProviderClient.kt
+++ b/src/commonMain/kotlin/com/liftric/cognito/idp/IdentityProviderClient.kt
@@ -73,7 +73,7 @@ open class IdentityProviderClient(region: String, clientId: String) : IdentityPr
 
     override suspend fun resendConfirmationCode(
         username: String
-    ): Result<CodeDeliveryDetails> = request(
+    ): Result<ResendConfirmationCodeResponse> = request(
         Request.ResendConfirmationCode,
         ResendConfirmationCode(
             ClientId = configuration.clientId,

--- a/src/commonMain/kotlin/com/liftric/cognito/idp/core/IdentityProvider.kt
+++ b/src/commonMain/kotlin/com/liftric/cognito/idp/core/IdentityProvider.kt
@@ -21,9 +21,9 @@ interface IdentityProvider {
     /**
      * Resends the confirmation (for confirmation of registration) to a specific user in the user pool.
      * @param username The username
-     * @return Result object containing CodeDeliveryDetails on success or an error on failure
+     * @return Result object containing ResendConfirmationCodeResponse on success or an error on failure
      */
-    suspend fun resendConfirmationCode(username: String): Result<CodeDeliveryDetails>
+    suspend fun resendConfirmationCode(username: String): Result<ResendConfirmationCodeResponse>
 
     /**
      * Signs in the user with the given parameters

--- a/src/commonMain/kotlin/com/liftric/cognito/idp/core/Response.kt
+++ b/src/commonMain/kotlin/com/liftric/cognito/idp/core/Response.kt
@@ -36,7 +36,7 @@ data class SignUpResponse(
 
 @Serializable
 data class ResendConfirmationCodeResponse(
-    val CodeDeliveryDetails: CodeDeliveryDetails? = null,
+    val CodeDeliveryDetails: CodeDeliveryDetails
 )
 
 @Serializable

--- a/src/commonMain/kotlin/com/liftric/cognito/idp/core/Response.kt
+++ b/src/commonMain/kotlin/com/liftric/cognito/idp/core/Response.kt
@@ -35,6 +35,11 @@ data class SignUpResponse(
 )
 
 @Serializable
+data class ResendConfirmationCodeResponse(
+    val CodeDeliveryDetails: CodeDeliveryDetails? = null,
+)
+
+@Serializable
 data class CodeDeliveryDetails(
     val AttributeName: String,
     val DeliveryMedium: String,

--- a/src/jsMain/kotlin/IdentityProviderJS.kt
+++ b/src/jsMain/kotlin/IdentityProviderJS.kt
@@ -28,10 +28,10 @@ class IdentityProviderClientJS(region: String, clientId: String) {
                 .getOrThrow()
         }
 
-    fun resendConfirmationCode(username: String): Promise<CodeDeliveryDetailsJS> =
+    fun resendConfirmationCode(username: String): Promise<ResendConfirmationCodeResponseJS> =
         MainScope().promise {
-            provider.resendConfirmationCode(username)
-                .getOrThrow().let { it.toJs() }
+            provider.forgotPassword(username)
+                .getOrThrow().let { ResendConfirmationCodeResponseJS(it.CodeDeliveryDetails.toJs()) }
         }
 
     fun signIn(username: String, password: String): Promise<SignInResponseJS> =

--- a/src/jsMain/kotlin/IdentityProviderJS.kt
+++ b/src/jsMain/kotlin/IdentityProviderJS.kt
@@ -30,7 +30,7 @@ class IdentityProviderClientJS(region: String, clientId: String) {
 
     fun resendConfirmationCode(username: String): Promise<ResendConfirmationCodeResponseJS> =
         MainScope().promise {
-            provider.forgotPassword(username)
+            provider.resendConfirmationCode(username)
                 .getOrThrow().let { ResendConfirmationCodeResponseJS(it.CodeDeliveryDetails.toJs()) }
         }
 

--- a/src/jsMain/kotlin/ResponseJS.kt
+++ b/src/jsMain/kotlin/ResponseJS.kt
@@ -102,3 +102,6 @@ data class MFAOptionsJS(
     val AttributeName: String,
     val DeliveryMedium: String
 )
+data class ResendConfirmationCodeResponseJS(
+    val CodeDeliveryDetails: CodeDeliveryDetailsJS
+)


### PR DESCRIPTION
@gaebel In PR https://github.com/Liftric/cognito-idp/pull/36 you asked me to use `CodeDeliveryDetails` as response type. However I made a mistake in the change there. Instead of wrapping the `CodeDeliveryDetails` in a new response object it's trying to parse the response json (which contains looks like `{"CodeDeliveryDetails":{"AttributeName":"phone_number","DeliveryMedium":"SMS","Destination":"+********0388"}}`) directly into a CodeDeliveryDetails. Which now results in an error. So this call currently always fails.

I've fixed it in this PR (and would greatly appreciate it if a new release could be made with this change since we currently have the error in our app on production, tnx!)