### PR TITLE
core/Result: functional programming addition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build testapp and test request (iOS)
         run: |
           cd iostests
-          xcodebuild clean test -project TestApp.xcodeproj -scheme TestApp -destination "platform=iOS Simulator,OS=15.0,name=iPhone 12" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO region=${{ secrets.region }} clientId=${{ secrets.clientid }}
+          xcodebuild clean test -project TestApp.xcodeproj -scheme TestApp -destination "platform=iOS Simulator,OS=15.2,name=iPhone 12" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO region=${{ secrets.region }} clientId=${{ secrets.clientid }}
       - name: Upload test result
         if: ${{ always() }}
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Our result is basically a classical Either.

This MR adds usual nice-to-have to decrease the overhead while modelling errors with Result:
![image](https://user-images.githubusercontent.com/16693237/154693564-676345b3-68ef-4bc6-a960-2e2993703c02.png)
`doTry` for easier Result creation and `andThen` for easier happy path programming.

If any block fails in our Result happy path, the result short-circuits and returns the exception.