### PR TITLE
Feature: Refactor Result and bump Dependencies

### DIFF
--- a/buildSrc/src/main/java/Libs.kt
+++ b/buildSrc/src/main/java/Libs.kt
@@ -14,7 +14,7 @@ object Versions {
     const val npmPublish = "2.1.1"
     const val definitions = "4.41.0"
     const val coroutines = "1.6.0-native-mt"
-    const val serialization = "1.3.2"
+    const val serialization = "1.3.1"
     const val ktor = "1.6.7"
     const val TestCore = "1.2.0"
     const val RoboElectric = "4.5.1"

--- a/buildSrc/src/main/java/Libs.kt
+++ b/buildSrc/src/main/java/Libs.kt
@@ -14,7 +14,7 @@ object Versions {
     const val npmPublish = "2.1.1"
     const val definitions = "4.41.0"
     const val coroutines = "1.6.0-native-mt"
-    const val serialization = "1.3.0"
+    const val serialization = "1.3.2"
     const val ktor = "1.6.7"
     const val TestCore = "1.2.0"
     const val RoboElectric = "4.5.1"

--- a/buildSrc/src/main/java/Libs.kt
+++ b/buildSrc/src/main/java/Libs.kt
@@ -10,12 +10,12 @@ object Android {
 
 object Versions {
     const val gradle = "7.0.0"
-    const val kotlin = "1.5.31"
+    const val kotlin = "1.6.10"
     const val npmPublish = "2.1.1"
     const val definitions = "4.41.0"
-    const val coroutines = "1.5.2-native-mt"
+    const val coroutines = "1.6.0-native-mt"
     const val serialization = "1.3.0"
-    const val ktor = "1.6.5"
+    const val ktor = "1.6.7"
     const val TestCore = "1.2.0"
     const val RoboElectric = "4.5.1"
 }

--- a/src/commonTest/kotlin/com/liftric/cognito/idp/ResultTests.kt
+++ b/src/commonTest/kotlin/com/liftric/cognito/idp/ResultTests.kt
@@ -125,7 +125,7 @@ class ResultTests {
     fun testOnResultChainingSuccess() {
         val expected = "Test"
         val result = Result.success(expected)
-            .onSuccess {
+            .onResult {
                 Result.success(expected.repeat(2))
             }.onResult {
                 Result.success(expected.repeat(3))

--- a/src/commonTest/kotlin/com/liftric/cognito/idp/ResultTests.kt
+++ b/src/commonTest/kotlin/com/liftric/cognito/idp/ResultTests.kt
@@ -1,10 +1,7 @@
 package com.liftric.cognito.idp
 
+import com.liftric.cognito.idp.core.*
 import io.ktor.utils.io.errors.*
-import com.liftric.cognito.idp.core.Result
-import com.liftric.cognito.idp.core.onFailure
-import com.liftric.cognito.idp.core.onResult
-import com.liftric.cognito.idp.core.onSuccess
 import kotlin.test.*
 
 class ResultTests {
@@ -68,9 +65,9 @@ class ResultTests {
     @Test
     fun testDoTryAndFold() {
         Result.doTry { "1" }
-            .andThen { "${it}2" }
-            .andThen { it.toInt() }
-            .andThen { it * 2 }
+            .map { "${it}2" }
+            .mapCatching { it.toInt() }
+            .map { it * 2 }
             .fold(onFailure = {fail("shouldn't fail!")}, onSuccess = { assertEquals(24, it) })
     }
 
@@ -78,7 +75,7 @@ class ResultTests {
     fun testAndThenOnSuccess() {
         var result: String? = null
         Result.success("Hans")
-            .andThen { "$it Wurst" }
+            .map { "$it Wurst" }
             .fold(
                 onSuccess = {
                     result = it
@@ -94,15 +91,13 @@ class ResultTests {
     fun testAndThenOnFailure() {
         val exception = Exception("firstException")
         val failedAndThen = Result.failure<String>(exception)
-            .andThen {
-                Result.success("won't happen")
-            }
+            .map { "won't happen" }
 
         assertEquals(true, failedAndThen.isFailure)
         assertEquals(exception, failedAndThen.exceptionOrNull())
 
         Result.success("Test")
-            .andThen {
+            .mapCatching {
                 error("sad")
             }.fold(onSuccess = {
                 fail("onSuccess() should not get called")
@@ -130,7 +125,7 @@ class ResultTests {
     fun testOnResultChainingSuccess() {
         val expected = "Test"
         val result = Result.success(expected)
-            .onResult {
+            .onSuccess {
                 Result.success(expected.repeat(2))
             }.onResult {
                 Result.success(expected.repeat(3))


### PR DESCRIPTION
- Bumped Kotlin (to 1.6.10) and the corresponding dependencies.
- Decided to bring the Result type closer to the one of the stdlb. Added `Deprecation` annotations with `ReplaceWith` for convenience.