### PR TITLE
feat: support ClientMetadata during SignUp and ForgotPassword

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.android.build.gradle.LibraryExtension
-import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.liftric.vault.GetVaultSecretTask
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest
 import org.jetbrains.kotlin.gradle.tasks.*
@@ -297,11 +296,6 @@ publishing {
                 }
             }
             developers {
-                developer {
-                    id.set("gaebel")
-                    name.set("Jan Gaebel")
-                    email.set("gaebel@liftric.com")
-                }
                 developer {
                     id.set("benjohnde")
                     name.set("Ben John")

--- a/src/commonMain/kotlin/com/liftric/cognito/idp/IdentityProviderClient.kt
+++ b/src/commonMain/kotlin/com/liftric/cognito/idp/IdentityProviderClient.kt
@@ -47,14 +47,16 @@ open class IdentityProviderClient(region: String, clientId: String, engine: Http
     override suspend fun signUp(
         username: String,
         password: String,
-        attributes: List<UserAttribute>?
+        attributes: List<UserAttribute>?,
+        clientMetadata: Map<String, String>?,
     ): Result<SignUpResponse> = request(
         Request.SignUp,
         SignUp(
             ClientId = configuration.clientId,
             Username = username,
             Password = password,
-            UserAttributes = attributes ?: listOf()
+            UserAttributes = attributes ?: listOf(),
+            ClientMetadata = clientMetadata,
         )
     )
 
@@ -157,12 +159,14 @@ open class IdentityProviderClient(region: String, clientId: String, engine: Http
     )
 
     override suspend fun forgotPassword(
-        username: String
+        username: String,
+        clientMetadata: Map<String, String>?
     ): Result<ForgotPasswordResponse> = request(
         Request.ForgotPassword,
         ForgotPassword(
             ClientId = configuration.clientId,
-            Username = username
+            Username = username,
+            ClientMetadata = clientMetadata,
         )
     )
 
@@ -183,7 +187,7 @@ open class IdentityProviderClient(region: String, clientId: String, engine: Http
     override suspend fun getUserAttributeVerificationCode(
         accessToken: String,
         attributeName: String,
-        clientMetadata: Map<String, String>?
+        clientMetadata: Map<String, String>?,
     ): Result<GetAttributeVerificationCodeResponse> = request(
         Request.GetUserAttributeVerificationCode,
         GetUserAttributeVerificationCode(

--- a/src/commonMain/kotlin/com/liftric/cognito/idp/core/IdentityProvider.kt
+++ b/src/commonMain/kotlin/com/liftric/cognito/idp/core/IdentityProvider.kt
@@ -8,7 +8,7 @@ interface IdentityProvider {
      * @param attributes Optional account attributes e.g. email, phone number, ...
      * @return Result object containing SignUpResponse on success or an error on failure
      */
-    suspend fun signUp(username: String, password: String, attributes: List<UserAttribute>? = null): Result<SignUpResponse>
+    suspend fun signUp(username: String, password: String, attributes: List<UserAttribute>? = null, clientMetadata: Map<String, String>? = null): Result<SignUpResponse>
 
     /**
      * Confirms sign up of a new user
@@ -91,7 +91,7 @@ interface IdentityProvider {
      * @param username The username
      * @return Result object containing CodeDeliveryDetails on success or an error on failure
      */
-    suspend fun forgotPassword(username: String): Result<ForgotPasswordResponse>
+    suspend fun forgotPassword(username: String, clientMetadata: Map<String, String>? = null): Result<ForgotPasswordResponse>
 
     /**
      * Confirms forgot password

--- a/src/commonMain/kotlin/com/liftric/cognito/idp/core/Payload.kt
+++ b/src/commonMain/kotlin/com/liftric/cognito/idp/core/Payload.kt
@@ -54,7 +54,8 @@ internal data class SignUp(
     val ClientId: String,
     val Password: String,
     val Username: String,
-    val UserAttributes: List<UserAttribute>
+    val UserAttributes: List<UserAttribute>,
+    val ClientMetadata: Map<String, String>?,
 )
 
 @Serializable
@@ -73,7 +74,8 @@ internal data class ResendConfirmationCode(
 @Serializable
 internal data class ForgotPassword(
     val ClientId: String,
-    val Username: String
+    val Username: String,
+    val ClientMetadata: Map<String, String>?,
 )
 
 @Serializable
@@ -101,7 +103,7 @@ internal data class UpdateUserAttributes(
 internal data class GetUserAttributeVerificationCode(
     val AccessToken: String,
     val AttributeName: String,
-    val ClientMetadata: Map<String, String>? = null
+    val ClientMetadata: Map<String, String>?
 )
 
 @Serializable

--- a/src/commonTest/kotlin/com/liftric/cognito/idp/IdentityProviderClientTests.kt
+++ b/src/commonTest/kotlin/com/liftric/cognito/idp/IdentityProviderClientTests.kt
@@ -68,7 +68,7 @@ abstract class AbstractIdentityProviderClientTests {
         val signUpResponse = provider.signUp(
             credentials.username, credentials.password,
             attributes = listOf(
-                UserAttribute(Name = "custom:target_group", Value = "ROLE_USER")
+                UserAttribute(Name = "custom:target_group", Value = "ROLE_PATIENT")
             )
         )
 

--- a/src/jsMain/kotlin/IdentityProviderJS.kt
+++ b/src/jsMain/kotlin/IdentityProviderJS.kt
@@ -15,13 +15,15 @@ class IdentityProviderClientJS(region: String, clientId: String) {
     fun signUp(
         username: String,
         password: String,
-        attributes: Array<UserAttribute>? = null
+        attributes: Array<UserAttribute>? = null,
+        clientMetadata: Array<MapEntry>? = null,
     ): Promise<SignUpResponse> =
         MainScope().promise {
             provider.signUp(
                 username = username,
                 password = password,
-                attributes = attributes?.toList()
+                attributes = attributes?.toList(),
+                clientMetadata = clientMetadata?.associate { it.key to it.value }
             ).getOrWrapThrowable()
         }
 
@@ -105,9 +107,9 @@ class IdentityProviderClientJS(region: String, clientId: String) {
             ).getOrWrapThrowable()
         }
 
-    fun forgotPassword(username: String): Promise<ForgotPasswordResponse> =
+    fun forgotPassword(username: String, clientMetadata: Array<MapEntry>? = null): Promise<ForgotPasswordResponse> =
         MainScope().promise {
-            provider.forgotPassword(username)
+            provider.forgotPassword(username, clientMetadata?.associate { it.key to it.value })
                 .getOrWrapThrowable()
         }
 

--- a/src/jsTest/kotlin/com/liftric/cognito/idp/IdentityProviderClientJSTests.kt
+++ b/src/jsTest/kotlin/com/liftric/cognito/idp/IdentityProviderClientJSTests.kt
@@ -5,6 +5,7 @@ import IdentityProviderExceptionJs
 import com.liftric.cognito.idp.core.UserAttribute
 import env
 import kotlinx.coroutines.await
+import toMapEntries
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -30,8 +31,34 @@ class IdentityProviderClientJSTests {
         provider.signUp(
             username, password,
             attributes = arrayOf(
-                UserAttribute(Name = "custom:target_group", Value = "ROLE_USER")
+                UserAttribute(Name = "custom:target_group", Value = "ROLE_PATIENT")
             )
+        ).await().also {
+            println("signUpResponse=$it")
+            assertNotNull(it)
+        }
+
+        provider.signIn(username, password).await().also {
+            println("signInResponse=$it")
+            assertNotNull(it)
+
+            provider.deleteUser(it.AuthenticationResult!!.AccessToken!!).await().also {
+                println("deleteUser=$it")
+                assertNotNull(it)
+            }
+        }
+    }
+
+    @JsName("SignUpSignInDeleteUserClientMetaDataTest")
+    @Test
+    fun `Sign up, sign in, delete user with clientMetadata should succeed`() = runTest {
+        println("Sign up, sign in, delete user should succeed")
+        provider.signUp(
+            username, password,
+            attributes = arrayOf(
+                UserAttribute(Name = "custom:target_group", Value = "ROLE_PATIENT")
+            ),
+            clientMetadata = mapOf("fallback_mode" to "true").toMapEntries(),
         ).await().also {
             println("signUpResponse=$it")
             assertNotNull(it)


### PR DESCRIPTION
Added according to https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-sign-up.html#cognito-user-pools-lambda-trigger-syntax-pre-signup